### PR TITLE
13" Screen Friendly

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -107,6 +107,7 @@ article h2 {
   background: url(/public/images/bgtexture2.png) repeat-y 100% top;
   color: #fff;
   text-align: center;
+  overflow-y: scroll;
 }
 .page-header .anvil-logo {
   margin: 44px auto 33px;
@@ -177,6 +178,7 @@ article h2 {
   -o-border-radius: 6px;
   border-radius: 6px;
   padding: 10px;
+  margin-bottom: 120px;
 }
 .page-header .documentation-nav h3 {
   margin: 10px 0;
@@ -205,7 +207,7 @@ article h2 {
   text-decoration: underline;
 }
 .page-header .compatibility {
-  position: absolute;
+  position: fixed;
   bottom: 55px;
   left: 37px;
   font-family: "museosansbold";
@@ -226,10 +228,10 @@ article h2 {
   margin-left: 10px;
 }
 .page-header .appendto-link {
-  position: absolute;
+  position: fixed;
   bottom: 0;
   left: 0;
-  width: 100%;
+  width: 352px;
   background-color: #000;
   font-family: "museosansbold";
   text-transform: uppercase;

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -104,6 +104,7 @@ article {
 	background: url(/public/images/bgtexture2.png) repeat-y 100% top;
 	color: #fff;
 	text-align: center;
+	overflow-y: scroll;
 
 	.anvil-logo { margin: 44px auto 33px; display: block; }
 
@@ -162,6 +163,7 @@ article {
 		background-color: rgba(68,68,68,.4);
 		@include border-radius( $br2 );
 		padding: 10px;
+		margin-bottom: 120px;
 
 		h3 { margin: 10px 0; color: $red; letter-spacing: 1px; }
 
@@ -181,7 +183,7 @@ article {
 	}
 
 	.compatibility {
-		position: absolute;
+		position: fixed;
 		bottom: 55px;
 		left: 37px;
 		font-family: "museosansbold";
@@ -206,10 +208,10 @@ article {
 	}
 
 	.appendto-link {
-		position: absolute;
+		position: fixed;
 		bottom: 0;
 		left: 0;
-		width: 100%;
+		width: 352px;
 		background-color: #000;
 		font-family: "museosansbold";
 		text-transform: uppercase;
@@ -250,12 +252,12 @@ article {
 		text-align: center;
 		display: inline;
 		list-style-type: none;
-		
+
   		h3 {
   			display: inline;
   		}
 
-  		a { 
+  		a {
   			@include transition-property(color);
 			@include transition-property(background-color);
 			@include transition-property(border);
@@ -304,7 +306,7 @@ article {
 		font-weight: normal; /* for FF */
 
 	}
-	
+
 	h1 {
 		margin-bottom: 0;
 	}


### PR DESCRIPTION
Made a couple of small changes that added scrolling for short screens that can't see all of the navigation options, but kept compatibility icons and appendTo banner visible at
all times.

![problem](https://f.cloud.github.com/assets/963786/225572/76ac34d4-85fb-11e2-91c5-a77f35edb0ba.jpg)
