### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-anviljs.com


### PR DESCRIPTION
Since anviljs.com is no longer registered, it doesn't resolve to the docs site anymore. This removes the CNAME so that it can simply resolve to http://anviljs.github.io.

Also, someone should update the URL in the organization description.

![image](https://cloud.githubusercontent.com/assets/1319791/6052223/3293dec0-ac85-11e4-8ca7-1aa27471968b.png)
